### PR TITLE
Delete extra constructor argument

### DIFF
--- a/Assets/Components/VRStreamer/Scripts/Streamer.cs
+++ b/Assets/Components/VRStreamer/Scripts/Streamer.cs
@@ -52,7 +52,7 @@ public class Streamer : MonoBehaviour
 
         _camera.CopyFrom(Camera.main);
 
-        _header = new HeaderMsg(0, new TimeMsg(0, 0), "VR");
+        _header = new HeaderMsg(new TimeMsg(0, 0), "VR");
 
         // _camera = Camera.main;
         _camera.targetTexture = _renderTexture;


### PR DESCRIPTION
This pull request makes a small change to the initialization of the `_header` object in the `Streamer.cs` script. The change updates the constructor for `HeaderMsg` to remove the first integer argument, as the constructor only expects a `TimeMsg` and a `frame_id` String