### PR TITLE
Add quest3 to supported devices

### DIFF
--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -44,6 +44,6 @@
             <meta-data android:name="notch_support" android:value="true"/>
             <meta-data android:name="com.oculus.vr.focusaware" android:value="true"/>
         </activity>
-        <meta-data android:name="com.oculus.supportedDevices" android:value="quest2|cambria"/>
+        <meta-data android:name="com.oculus.supportedDevices" android:value="quest2|cambria|eureka|quest3s"/>
     </application>
 </manifest>


### PR DESCRIPTION
Need to add Quest3 to the list of supported devices in the manifest in order to build the standalone version.

<img width="647" height="208" alt="image" src="https://github.com/user-attachments/assets/f1406a06-70f1-41d4-b5b1-44f622505e01" />
