### PR TITLE
Fix `/quest/hand_points` publisher

### DIFF
--- a/Assets/Components/Hands/Scripts/HandPub.cs
+++ b/Assets/Components/Hands/Scripts/HandPub.cs
@@ -73,6 +73,9 @@ public class HandPub : MonoBehaviour
         {
             _publishing = PlayerPrefs.GetInt("handPublishing") == 1;
             _img.sprite = _publishing ? enableIcon : disableIcon;
+        } else {
+            _publishing = true;
+            _img.sprite = enableIcon;
         }
 
         var _handSubsystem = new List<XRHandSubsystem>();

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -212,6 +212,34 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3937090859134365811, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937090859134365811, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937090859134365811, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 639842762}
+    - target: {fileID: 3937090859134365811, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937090859134365811, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: TogglePublishing
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937090859134365811, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: HandPub, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 3937090859134365811, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 5213991793620426796, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -313,6 +341,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}
+--- !u!114 &639842762 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5803993673259278102, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}
+  m_PrefabInstance: {fileID: 639842761}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b0d973c72f791e16b48322cc5abfc89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &639842764 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 9192392808969577600, guid: 284c18ecc4f72ec20968371b116bf40b, type: 3}


### PR DESCRIPTION
This PR addresses #19, where the `/quest/hand_point` publisher was not being properly enabled in existing builds.

The default value for `_publishing` has been changed to true and the toggle button under the WiFi menu has been properly linked to trigger the HandPub toggle function now.