### PR TITLE
Update ROS TCP Connector to include ROS1/2 switching

### DIFF
--- a/Assets/Components/Lidar/README.md
+++ b/Assets/Components/Lidar/README.md
@@ -6,4 +6,8 @@
 
 This component uses shaders to quickly and efficently render pointcloud 2 methods. There is a dropdown in the inspector for `Viz Type` which allows you to select which type of pointcloud you want to view. The main difference is that `Lidar` will look for an intensity field and render colors based on that, while the `RGB` will use the colors from the RGB field. For dense pointclouds, it can be helpful to downsample the number of points rendered, this can be done via the `Display Pts` field which has a delegate for dynamically changing this value in runtime.
 
+This component also contains the `Splat` viz type, which will render pointcloud 2 data with the necessary fields (Splat Format: x, y, z, rgb, scalex, scaley, scalez, rot0, rot1, rot2, rot3, nx, ny, nz, fc_dc_0, fc_dc_1, fc_dc_2, opacity) as live Gaussian splats.
+
+![Splat video](/docs/images/HeadsetSplatStreaming.gif)
+
 ![Lidar Inspector](/docs/images/lidar_inspector.png)

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -295,14 +295,14 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "c9d3801989ffd6a5c265f9a995c0e71ad4fe10ff"
+      "hash": "65aca1b443e39dec3c2cae1c39af41d13a6dd305"
     },
     "com.unity.robotics.visualizations": {
       "version": "https://github.com/leggedrobotics/ROS-TCP-Connector.git?path=/com.unity.robotics.visualizations",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "4a5b255f369421bfa8e36c958ad8bbbb5320e3d6"
+      "hash": "65aca1b443e39dec3c2cae1c39af41d13a6dd305"
     },
     "com.unity.searcher": {
       "version": "4.9.3",


### PR DESCRIPTION
This updates the ROS TCP Connector to include ROS1/2 switching, letting us easily swap between endpoints running different ROS versions.

Also includes some documentation updates showcasing the splat functionality.