### PR TITLE
Add ROS version to debug menu

### DIFF
--- a/Assets/Components/Menu/Scripts/GetIpAddress.cs
+++ b/Assets/Components/Menu/Scripts/GetIpAddress.cs
@@ -2,20 +2,35 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Net;
+using Unity.Robotics.ROSTCPConnector;
 
 public class GetIpAddress : MonoBehaviour
 {
     private TMPro.TextMeshProUGUI _text;
 
+    private string _ipAddress;
+
+    private ROSConnection _ros;
+
     void Start()
     {
         _text = GetComponent<TMPro.TextMeshProUGUI>();
-        _text.text = GetLocalIPv4();
+        _ros = ROSConnection.GetOrCreateInstance();
+        _ipAddress = GetLocalIPv4();
+        _text.text = _ros.rosVersion.ToString() + " : " + _ipAddress;
     }
 
     public string GetLocalIPv4()
     {
         return Dns.GetHostEntry(Dns.GetHostName()).AddressList[0].ToString();
+    }
+
+    public void Update()
+    {
+        if (_text.enabled)
+        {
+            _text.text = _ros.rosVersion.ToString() + " : " + _ipAddress;
+        }
     }
 
     public void ToggleVisible()


### PR DESCRIPTION
Adds the current ROS version being used by the ROS TCP Connector to the debug menu next to the IP address.

<img width="1930" height="712" alt="image" src="https://github.com/user-attachments/assets/0d486ebc-be26-49d8-8b12-ff528bb4a655" />
